### PR TITLE
List `setuptools` Dependency in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires-python = ">=3.6"
 dependencies = [
     "click>=8.0.3",
     "pypdf>=3.0.0",
+    "setuptools>=68.2.2",
 ]
 license = { file = "LICENSE" }
 keywords = [ "pdf", "cli", "pypdf", "click" ]


### PR DESCRIPTION
This project requires it, but it wasn't listed. I just listed the latest version.